### PR TITLE
Add demoURL to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
     "ember-addon"
   ],
   "ember-addon": {
-    "configPath": "tests/dummy/config"
+    "configPath": "tests/dummy/config",
+    "demoURL": "http://indexiatech.github.io/ember-idx-button"
   },
   "dependencies": {
     "ember-idx-utils": "^0.2.2",


### PR DESCRIPTION
emberaddons.com provides a demo link if the ember addon has the demoURL set